### PR TITLE
feat: deprecated extension `toView` to Screen object

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/ScreenExtensions.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/ScreenExtensions.kt
@@ -21,8 +21,22 @@ import androidx.fragment.app.Fragment
 import br.com.zup.beagle.android.components.layout.Screen
 import br.com.zup.beagle.android.components.layout.ScreenComponent
 
+@Deprecated(
+    "It was deprecated in version 1.10.0 and will be removed in a future version." +
+            " Use the load view with screenJson.",
+    ReplaceWith(
+        "viewGroup.loadView(activity, screenJson, screenId)"
+    )
+)
 fun Screen.toView(activity: AppCompatActivity) = this.toComponent().toView(activity)
 
+@Deprecated(
+    "It was deprecated in version 1.10.0 and will be removed in a future version." +
+            " Use the load view with screenJson.",
+    ReplaceWith(
+        "viewGroup.loadView(activity, screenJson, screenId)"
+    )
+)
 fun Screen.toView(fragment: Fragment) = this.toComponent().toView(fragment)
 
 internal fun Screen.toComponent() = ScreenComponent(


### PR DESCRIPTION
### Description and Example

Deprecated extension toView to Screen

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow-up on review comments in a timely manner.
- [X] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
