### PR TITLE
chore: adjust PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Please, check if these important points are met using `[x]`:
 
 - [ ] I read the [PR Guide] and followed the process outlined there for submitting this PR.
 - [ ] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
-- [ ] I am willing to follow-up on review comments in a timely manner.
+- [ ] I am willing to follow up on review comments in a timely manner.
 - [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:
 
 <!-- Links -->


### PR DESCRIPTION
Signed-off-by: Paulo Cesar Meurer <paulo.meurer@zup.com.br>

### Description and Example

Correct a typo in the PR template text. Follow up as a verb doesn't have a hyphen.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow up on review comments in a timely manner.
- [X] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
