### PR TITLE
fix: android textView

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/ViewFactory.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/ViewFactory.kt
@@ -25,8 +25,8 @@ import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
 import android.widget.ScrollView
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import br.com.zup.beagle.R
@@ -73,9 +73,9 @@ internal object ViewFactory {
 
     fun makeButton(context: Context) = Button(context)
 
-    fun makeTextView(context: Context) = TextView(context)
+    fun makeTextView(context: Context) = AppCompatTextView(context)
 
-    fun makeTextView(context: Context, id: Int) = TextView(ContextThemeWrapper(context, id), null, 0)
+    fun makeTextView(context: Context, id: Int) = AppCompatTextView(ContextThemeWrapper(context, id), null, 0)
 
     fun makeInputText(context: Context, id: Int) = EditText(ContextThemeWrapper(context, id), null, 0)
 


### PR DESCRIPTION
Signed-off-by: carlossteinzup <carlos.stein@zup.com.br>

### Related Issues
issue: https://github.com/ZupIT/beagle/issues/1746

### Description and Example
A font type won't be applied to a textView created through Beagle on Android 7 (API 24) when loaded from res/font

* the default types from Android works ok, as the type "cursive", but imported types won't be applied for Android 7.
* The imported fonts work on the current APIs above 26.

This happens because when creating the native views for Text in Android, a regular library for TextView (android.widget.TextView) was being used. Updating that to the AppCompatVersion has solved this issue.
* In order to prevent future issues like this one, the Button and EditText libraries were also updated to their AppCompatVersions since they extend properties from the TextView as well.

### Checklist

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
