### PR TITLE
fix: Updates some view libraries to their AppCompat versions. 

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/ViewFactory.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/ViewFactory.kt
@@ -20,13 +20,13 @@ import android.content.Context
 import android.view.ContextThemeWrapper
 import android.view.View
 import android.webkit.WebView
-import android.widget.Button
-import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
 import android.widget.ScrollView
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.widget.AppCompatButton
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import br.com.zup.beagle.R
@@ -69,17 +69,17 @@ internal object ViewFactory {
         isFillViewport = true
     }
 
-    fun makeButton(context: Context, id: Int) = Button(ContextThemeWrapper(context, id), null, 0)
+    fun makeButton(context: Context, id: Int) = AppCompatButton(ContextThemeWrapper(context, id), null, 0)
 
-    fun makeButton(context: Context) = Button(context)
+    fun makeButton(context: Context) = AppCompatButton(context)
 
-    fun makeTextView(context: Context) = TextView(context)
+    fun makeTextView(context: Context) = AppCompatTextView(context)
 
-    fun makeTextView(context: Context, id: Int) = TextView(ContextThemeWrapper(context, id), null, 0)
+    fun makeTextView(context: Context, id: Int) = AppCompatTextView(ContextThemeWrapper(context, id), null, 0)
 
-    fun makeInputText(context: Context, id: Int) = EditText(ContextThemeWrapper(context, id), null, 0)
+    fun makeInputText(context: Context, id: Int) = AppCompatEditText(ContextThemeWrapper(context, id), null, 0)
 
-    fun makeInputText(context: Context) = EditText(context)
+    fun makeInputText(context: Context) = AppCompatEditText(context)
 
     fun makeAlertDialogBuilder(context: Context) = AlertDialog.Builder(context)
 

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/components/BeagleTextViewExtensionsKtTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/components/BeagleTextViewExtensionsKtTest.kt
@@ -21,6 +21,7 @@ import android.graphics.Color
 import android.view.Gravity
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.widget.TextViewCompat
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.setup.DesignSystem
@@ -50,7 +51,7 @@ class BeagleTextViewExtensionsKtTest : BaseComponentTest() {
 
     private val designSystem: DesignSystem = mockk()
     private val activity: AppCompatActivity = mockk(relaxed = true)
-    private val textView: TextView = mockk(relaxed = true)
+    private val textView: AppCompatTextView = mockk(relaxed = true)
     private val styleManager: StyleManager = mockk(relaxed = true)
 
     private val textValueSlot = slot<String>()

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/components/TextInputTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/components/TextInputTest.kt
@@ -21,6 +21,8 @@ import android.text.InputType
 import android.text.TextWatcher
 import android.view.View
 import android.widget.EditText
+import androidx.appcompat.widget.AppCompatEditText
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.widget.TextViewCompat
 import br.com.zup.beagle.android.action.SetContext
 import br.com.zup.beagle.android.context.Bind
@@ -61,7 +63,7 @@ internal class TextInputTest : BaseComponentTest() {
 
     private val focusCapture = slot<View.OnFocusChangeListener>()
     private val textWatcherCapture = slot<TextWatcher>()
-    private val editText: EditText = mockk(relaxed = true, relaxUnitFun = true)
+    private val editText: AppCompatEditText = mockk(relaxed = true, relaxUnitFun = true)
     private val styleManager: StyleManager = mockk(relaxed = true)
     private val context: Context = mockk()
     private val textWatcher: TextWatcher = mockk()

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/components/TextTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/components/TextTest.kt
@@ -16,7 +16,7 @@
 
 package br.com.zup.beagle.android.components
 
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import br.com.zup.beagle.android.utils.StyleManager
 import br.com.zup.beagle.android.view.ViewFactory
 import io.mockk.every
@@ -36,7 +36,7 @@ private const val DEFAULT_STYLE_INTEGER = 123
 @DisplayName("Given a Container")
 class TextTest : BaseComponentTest() {
 
-    private val textView: TextView = mockk(relaxed = true)
+    private val textView: AppCompatTextView = mockk(relaxed = true)
 
     private lateinit var text: Text
 
@@ -56,7 +56,7 @@ class TextTest : BaseComponentTest() {
             val view = text.buildView(rootView)
 
             // Then
-            assertTrue(view is TextView)
+            assertTrue(view is AppCompatTextView)
             verify(exactly = 1) { ViewFactory.makeTextView(rootView.getContext()) }
         }
 
@@ -81,7 +81,7 @@ class TextTest : BaseComponentTest() {
             val view = text.buildView(rootView)
 
             // Then
-            assertTrue(view is TextView)
+            assertTrue(view is AppCompatTextView)
 
             verify(exactly = 1) {
                 ViewFactory.makeTextView(any(), any())

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/engine/renderer/ui/UndefinedViewRendererTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/engine/renderer/ui/UndefinedViewRendererTest.kt
@@ -18,7 +18,7 @@
 package br.com.zup.beagle.android.engine.renderer.ui
 
 import android.graphics.Color
-import android.widget.TextView
+import androidx.appcompat.widget.AppCompatTextView
 import br.com.zup.beagle.android.components.BaseComponentTest
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.setup.Environment
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.Test
 
 class UndefinedViewRendererTest : BaseComponentTest() {
 
-    private val textView: TextView = mockk()
+    private val textView: AppCompatTextView = mockk()
 
     private val textSlot = slot<String>()
     private val textColorSlot = slot<Int>()
@@ -75,7 +75,7 @@ class UndefinedViewRendererTest : BaseComponentTest() {
     fun build_should_create_a_TexView_with_a_undefinedWidget_text() {
         val actual = undefinedViewRenderer.buildView(rootView)
 
-        assertTrue(actual is TextView)
+        assertTrue(actual is AppCompatTextView)
         assertEquals("undefined component", textSlot.captured)
     }
 


### PR DESCRIPTION
to use the AppCompat versions for TExtView, EditView e Button. The tests were also updated

Signed-off-by: carlossteinzup <carlos.stein@zup.com.br>

### Related Issues
Issue https://github.com/ZupIT/beagle/issues/1746

### Description and Example

A font type won't be applied to a textView created through Beagle on Android 7 (API 24) when loaded from res/font

* the default types from Android works ok, as the type "cursive", but imported types won't be applied for Android 7.
* The imported fonts work on the current APIs above 26.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
