### PR TITLE
fix: remove field doesn't need in ListView

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/components/ListView.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/components/ListView.kt
@@ -35,7 +35,6 @@ import br.com.zup.beagle.android.view.viewmodel.ListViewIdViewModel
 import br.com.zup.beagle.android.widget.RootView
 import br.com.zup.beagle.android.widget.WidgetView
 import br.com.zup.beagle.android.annotation.RegisterWidget
-import br.com.zup.beagle.android.widget.core.ServerDrivenComponent
 import br.com.zup.beagle.android.widget.core.ListDirection
 
 /**
@@ -56,7 +55,6 @@ import br.com.zup.beagle.android.widget.core.ListDirection
 
 @RegisterWidget("listView")
 data class ListView constructor(
-    val children: List<ServerDrivenComponent>? = null,
     val direction: ListDirection = ListDirection.VERTICAL,
     override val context: ContextData? = null,
     override val onInit: List<Action>? = null,

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/data/serializer/SerializerDataFactory.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/data/serializer/SerializerDataFactory.kt
@@ -275,7 +275,6 @@ fun makeObjectLazyComponent() = LazyComponent(
 fun makeListViewJson() = """
     {
        "_beagleComponent_":"beagle:listview",
-       "children": [${makeTextJson()}],
        "direction":"VERTICAL",
        "context": ${makeContextWithPrimitiveValueJson()},
        "onInit": [${makeActionAlertJson()}],
@@ -295,7 +294,6 @@ fun makeListViewJson() = """
 """
 
 fun makeObjectListView() = ListView(
-    children = listOf(makeObjectText()),
     direction = ListDirection.VERTICAL,
     context = makeObjectContextWithPrimitiveValue(),
     onInit = listOf(makeActionAlertObject()),


### PR DESCRIPTION
### Description and Example

The field `children` in ListView doesn't use more.

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow up on review comments in a timely manner.
- [X] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
