### PR TITLE
fix: ListView id manager when nested

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/components/list/ListAdapter.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/components/list/ListAdapter.kt
@@ -47,7 +47,9 @@ internal class ListAdapter(
     // Recyclerview id for post config changes id management
     private var recyclerId = View.NO_ID
 
+    // Parent list information needed by inner lists
     private var parentListViewSuffix: String? = null
+    private var parentListViewId: Int? = null
 
     // Serializer to provide new template instances
     private val serializer = BeagleSerializer()
@@ -125,8 +127,9 @@ internal class ListAdapter(
         }
     }
 
-    fun setParentSuffix(itemSuffix: String) {
+    fun setParentAttributes(itemSuffix: String, parentListId: Int) {
         parentListViewSuffix = itemSuffix
+        parentListViewId = parentListId
     }
 
     override fun getItemViewType(position: Int): Int {
@@ -268,14 +271,15 @@ internal class ListAdapter(
     }
 
     private fun createTempId(): Int {
-        recyclerId = listViewModels
-            .generateIdViewModel
-            .getViewId(
-                listViewModels
-                    .rootView
-                    .getParentId()
-            )
-
+        recyclerId = if (parentListViewSuffix != null && parentListViewId != null) {
+            listViewModels
+                .listViewIdViewModel
+                .getViewId(parentListViewId!!, parentListViewSuffix!!.toInt())
+        } else {
+            listViewModels
+                .generateIdViewModel
+                .getViewId(listViewModels.rootView.getParentId())
+        }
         return recyclerId
     }
 

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/components/list/ListViewHolder.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/components/list/ListViewHolder.kt
@@ -140,8 +140,8 @@ internal class ListViewHolder(
                 // When this item is not recycled, we simply recover your current adapters
                 saveCreatedAdapterToEachDirectNestedRecycler(listItem)
             }
-            // We inform to each adapters directly nested the suffix
-            updateDirectNestedAdaptersSuffix(listItem)
+            // We inform to each adapters directly nested the suffix and the current recyclerId
+            updateDirectNestedAdaptersInformation(listItem, recyclerId)
         } else {
             // But if that item on the list already has ids created, we retrieve them
             restoreIds(listItem)
@@ -300,9 +300,9 @@ internal class ListViewHolder(
         }
     }
 
-    private fun updateDirectNestedAdaptersSuffix(listItem: ListItem) {
+    private fun updateDirectNestedAdaptersInformation(listItem: ListItem, recyclerId: Int) {
         listItem.directNestedAdapters.forEach {
-            it.setParentSuffix(listItem.itemSuffix)
+            it.setParentAttributes(listItem.itemSuffix, recyclerId)
         }
     }
 

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/ServerDrivenActivity.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/ServerDrivenActivity.kt
@@ -42,7 +42,6 @@ class ServerDrivenActivity : BeagleActivity() {
         when (state) {
             is ServerDrivenState.Started -> {
                 showLoading(true)
-                binding.serverDrivenContainer.visibility = View.GONE
             }
             is ServerDrivenState.Error -> {
                 handleError(state)

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/components/list/ListAdapterTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/components/list/ListAdapterTest.kt
@@ -481,10 +481,9 @@ class ListAdapterTest : BaseTest() {
 
         val viewHolderMock = mockk<ListViewHolder>(relaxed = true)
         val positionMock = 0
-        val parentListViewSuffixMock = "parent"
+        val parentListViewSuffixMock = null
         val recyclerIdMock = 10
         val listItemMock = ListItem(data = list[positionMock])
-        listAdapter.setParentSuffix(parentListViewSuffixMock)
         listAdapter.setList(list)
 
         listAdapter.onBindViewHolder(viewHolderMock, positionMock)

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/components/list/ListAdapterTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/components/list/ListAdapterTest.kt
@@ -478,7 +478,6 @@ class ListAdapterTest : BaseTest() {
 
     @Test
     fun `Given a ListAdapter When call onBindViewHolder Then should call viewHolder onBind`() {
-
         val viewHolderMock = mockk<ListViewHolder>(relaxed = true)
         val positionMock = 0
         val parentListViewSuffixMock = null

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/components/list/ListViewHolderTest.kt
@@ -491,11 +491,13 @@ class ListViewHolderTest : BaseTest() {
         fun updateDirectNestedAdaptersSuffix() {
             // Given
             val suffix = "suffix"
+            val recyclerId = 1
             val listItem = ListItem(data = "stub", itemSuffix = suffix)
             val itemView = mockk<RecyclerView>(relaxed = true)
             val itemSuffixSlot = slot<String>()
+            val recyclerIdSlot = slot<Int>()
             val adapter = mockk<ListAdapter>(relaxed = true) {
-                every { setParentSuffix(capture(itemSuffixSlot)) } just Runs
+                every { setParentAttributes(capture(itemSuffixSlot), capture(recyclerIdSlot)) } just Runs
             }
             every { itemView.adapter } returns adapter
             listViewHolder = ListViewHolder(
@@ -508,10 +510,11 @@ class ListViewHolderTest : BaseTest() {
             )
 
             // When
-            listViewHolder.onBind(null, null, listItem, 0, 0)
+            listViewHolder.onBind(null, null, listItem, 0, recyclerId)
 
             // Then
             assertEquals(suffix, itemSuffixSlot.captured)
+            assertEquals(recyclerId, recyclerIdSlot.captured)
         }
 
         @DisplayName("Then should restoreIds to a not firstTimeBinding item")

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.15.1"
         classpath "de.mannodermaus.gradle.plugins:android-junit5:1.7.1.1"


### PR DESCRIPTION
### Description and Example

There are two algorithms for controlling the id of views in Beagle, one exclusively for ListViews and one for other views. When components are being rendered the default ids algorithm is used. However, when a list is found its specific algorithm is used.

The problem this PR solves is the scenario where a nested list used the default ids algorithm instead of using the list specific algorithm.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
