### PR TITLE
feat: ViewClient with prefetch cache

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/data/ComponentRequester.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/data/ComponentRequester.kt
@@ -33,7 +33,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 internal class ComponentRequester(
-    private val viewClient: ViewClient = BeagleEnvironment.beagleSdk.viewClient ?: ViewClientDefault,
+    private val viewClient: ViewClient = BeagleEnvironment.beagleSdk.viewClient ?: ViewClientDefault.instance,
     private val serializer: BeagleSerializer = BeagleSerializer(),
 ) {
 

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/networking/ViewClient.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/networking/ViewClient.kt
@@ -18,22 +18,38 @@ package br.com.zup.beagle.android.networking
 
 /**
  * ViewClient is the contract responsible for making requests
- * that load the Beagle's components and actions.
+ * that load the Beagle's components.
  */
 interface ViewClient {
 
     /**
-     * Method that executes the request.
+     * Method that executes requests to fetch views.
      * This is the recommended place to do processing
      * before and after the request happens, such as caching.
-     * @param requestData carries all the information of the request
-     * @param onSuccess
-     * @param onError
-     * @return
+     * @param requestData carries all the information of the request.
+     * @param onSuccess function that fires when the request is successfully completed.
+     * @param onError function that fires when there is an error in the request.
+     * @return [RequestCall] contract to make it possible to cancel the request.
+     * It returns null when the request is already cached.
      */
     fun fetch(
         requestData: RequestData,
         onSuccess: OnSuccess,
         onError: OnError,
-    ): RequestCall
+    ): RequestCall?
+
+    /**
+     * Method that executes requests to fetch views and cache them.
+     * This is triggered only if the shouldPrefetch attribute is enabled.
+     * @param requestData carries all the information of the request.
+     * @param onSuccess function that fires when the request is successfully completed.
+     * @param onError function that fires when there is an error in the request.
+     * @return [RequestCall] contract to make it possible to cancel the request.
+     * It returns null when the request is already cached.
+     */
+    fun prefetch(
+        requestData: RequestData,
+        onSuccess: OnSuccess,
+        onError: OnError,
+    ): RequestCall?
 }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/networking/ViewClientDefault.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/networking/ViewClientDefault.kt
@@ -19,10 +19,10 @@ package br.com.zup.beagle.android.networking
 import br.com.zup.beagle.android.setup.BeagleEnvironment
 import br.com.zup.beagle.android.utils.doRequest
 
-object ViewClientDefault : ViewClient {
-
-    private val httpClient by lazy { BeagleEnvironment.beagleSdk.httpClientFactory?.create() }
+class ViewClientDefault(
+    private val httpClient: HttpClient? = BeagleEnvironment.beagleSdk.httpClientFactory?.create(),
     private val cachedResponses: MutableMap<String, ResponseData> = mutableMapOf()
+) : ViewClient {
 
     override fun fetch(requestData: RequestData, onSuccess: OnSuccess, onError: OnError): RequestCall? {
         val cachedResponse = cachedResponses[requestData.url]
@@ -46,5 +46,9 @@ object ViewClientDefault : ViewClient {
                 cachedResponses[requestData.url] = response
             }, onError)
         }
+    }
+
+    companion object {
+        internal val instance = ViewClientDefault()
     }
 }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/RequestDataExtensions.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/RequestDataExtensions.kt
@@ -16,7 +16,6 @@
 
 package br.com.zup.beagle.android.utils
 
-import br.com.zup.beagle.android.data.formatUrl
 import br.com.zup.beagle.android.exception.BeagleApiException
 import br.com.zup.beagle.android.logger.BeagleMessageLogs
 import br.com.zup.beagle.android.networking.HttpClient
@@ -36,12 +35,11 @@ internal fun RequestData.doRequest(
                 data = "An instance of HttpClient was not found.".toByteArray(),
             ), this)
     }
-    val transformedRequest = this.copy(url = this.url.formatUrl())
 
-    BeagleMessageLogs.logHttpRequestData(transformedRequest)
+    BeagleMessageLogs.logHttpRequestData(this)
 
     return httpClient.execute(
-        request = transformedRequest,
+        request = this,
         onSuccess = { response ->
             BeagleMessageLogs.logHttpResponseData(response)
             onSuccess(response)
@@ -50,7 +48,7 @@ internal fun RequestData.doRequest(
         val exception = BeagleApiException(
             response,
             this,
-            "FetchData error for url ${transformedRequest.url}",
+            "FetchData error for url ${this.url}",
         )
         BeagleMessageLogs.logUnknownHttpError(exception)
     })

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleNavigator.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleNavigator.kt
@@ -25,7 +25,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentActivity
 import br.com.zup.beagle.android.action.Route
 import br.com.zup.beagle.android.context.ContextData
-import br.com.zup.beagle.android.data.formatUrl
 import br.com.zup.beagle.android.logger.BeagleLoggerProxy
 import br.com.zup.beagle.android.networking.HttpAdditionalData
 import br.com.zup.beagle.android.networking.HttpMethod
@@ -219,9 +218,8 @@ internal object BeagleNavigator {
             headers = route.httpAdditionalData?.headers ?: hashMapOf()
         )
 
-        val url = (route.url.value as String).formatUrl()
         return RequestData(
-            url = url,
+            url = route.url.value as String,
             httpAdditionalData = httpAdditionalData,
         )
     }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/viewmodel/BeagleViewModel.kt
@@ -50,8 +50,13 @@ internal open class BeagleViewModel(
     var fetchComponent: FetchComponentLiveData? = null
 
     fun fetchComponent(requestData: RequestData, screen: ServerDrivenComponent? = null): LiveData<ViewState> {
-        val fetchComponentLiveData = FetchComponentLiveData(requestData, screen, componentRequester,
-            viewModelScope, ioDispatcher)
+        val fetchComponentLiveData = FetchComponentLiveData(
+            requestData,
+            screen,
+            componentRequester,
+            viewModelScope,
+            ioDispatcher,
+        )
         fetchComponent = fetchComponentLiveData
 
         return fetchComponentLiveData
@@ -59,7 +64,7 @@ internal open class BeagleViewModel(
 
     fun fetchForCache(url: String) = viewModelScope.launch(ioDispatcher) {
         try {
-            componentRequester.fetchComponent(RequestData(url = url))
+            componentRequester.prefetchComponent(RequestData(url = url))
         } catch (exception: BeagleException) {
             BeagleLoggerProxy.warning(exception.message)
         }

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/networking/ViewClientDefaultTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/networking/ViewClientDefaultTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.networking
+
+import br.com.zup.beagle.android.BaseTest
+import br.com.zup.beagle.android.utils.doRequest
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Given a ViewClientDefault")
+class ViewClientDefaultTest : BaseTest() {
+
+    private val url = "https://www.test.com/test"
+    private val requestData: RequestData = mockk()
+    private val httpClient: HttpClient = mockk(relaxed = true)
+    private val onSuccess: OnSuccess = mockk()
+    private val onError: OnError = mockk()
+    private val requestCall: RequestCall = mockk()
+
+    val viewClientDefault = ViewClientDefault
+
+    @BeforeAll
+    override fun setUp() {
+        super.setUp()
+        every { beagleSdk.httpClientFactory } returns mockk() {
+            every { create() } returns httpClient
+        }
+        every { requestData.url } returns url
+    }
+
+    @Nested
+    @DisplayName("When fetch is called")
+    inner class Fetch {
+
+        @Test
+        @DisplayName("Then should call doRequest if cache is empty")
+        fun testFetchWithoutCache() {
+            // Given
+//            every { requestData.doRequest(httpClient, onSuccess, onError) } returns requestCall
+
+            // When
+//            val call = viewClientDefault.fetch(requestData, onSuccess, onError)
+
+            // Then
+//            assertEquals(requestCall, call)
+//            verify(exactly = 1) { requestData.doRequest(httpClient, onSuccess, onError) }
+        }
+
+        @Test
+        @DisplayName("Then should return and remove the cached response")
+        fun testFetchWithCache() {
+            // Given
+//            viewClientDefault.prefetch(requestData, onSuccess, onError)
+
+            // When
+//            val call = viewClientDefault.fetch(requestData, onSuccess, onError)
+
+            // Then
+//            assertEquals(null, call)
+            // check onSuccess with cached value
+        }
+    }
+
+    @Nested
+    @DisplayName("When prefetch is called")
+    inner class Prefetch {
+        // same asserts with prefetch method
+    }
+}

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/view/BeagleNavigatorTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/view/BeagleNavigatorTest.kt
@@ -273,7 +273,7 @@ class BeagleNavigatorTest : BaseTest() {
         @Test
         fun testPushViewShouldCallBeagleActivityNavigateTo() {
             // Given
-            val url = (route.url.value as String).formatUrl()
+            val url = route.url.value as String
 
             val requestData = RequestData(url = url)
             every { context.navigateTo(requestData, null, contextData) } just Runs


### PR DESCRIPTION
Signed-off-by: Matheus Ribeiro <matheus.ribeiro@zup.com.br>


### Related Issues

Part of [#1739](https://github.com/ZupIT/beagle/issues/1739)

### Description and Example

This PR changes the `ViewClient` contract to handle `prefetch` method calls. The `ViewClientDefault` implementation caches the result data from prefetch and use it to return the `fetch` calls.
This PR also centralizes the `formatUrl()` calls inside the `ComponentRequester` class, just like the `ActionRequesterViewModel` does calling the `toRequestData()` method.

TODO: `ViewClientDefault` tests must be done.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [ ] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
