### PR TITLE
feat: add support to the list of actions in fields inside action alert and confirm

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/action/Alert.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/action/Alert.kt
@@ -40,7 +40,7 @@ import br.com.zup.beagle.android.analytics.ActionAnalyticsConfig
 data class Alert(
     val title: Bind<String>? = null,
     val message: Bind<String>,
-    val onPressOk: Action? = null,
+    val onPressOk: List<Action>? = null,
     val labelOk: String? = null,
     override var analytics: ActionAnalyticsConfig? = null,
 ) : AnalyticsAction {

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/action/Confirm.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/action/Confirm.kt
@@ -41,8 +41,8 @@ import br.com.zup.beagle.android.analytics.ActionAnalyticsConfig
 data class Confirm(
     val title: Bind<String>? = null,
     val message: Bind<String>,
-    val onPressOk: Action? = null,
-    val onPressCancel: Action? = null,
+    val onPressOk: List<Action>? = null,
+    val onPressCancel: List<Action>? = null,
     val labelOk: String? = null,
     val labelCancel: String? = null,
     override var analytics: ActionAnalyticsConfig? = null,

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/action/AlertTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/action/AlertTest.kt
@@ -130,7 +130,7 @@ class AlertTest {
     @Test
     fun `should handle onPressOk when click in button`() {
         // Given
-        val onPressOk: List<Action> = listOf()
+        val onPressOk: List<Action> = listOf(mockk(relaxed = true))
         val action = Alert(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/action/AlertTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/action/AlertTest.kt
@@ -24,11 +24,9 @@ import br.com.zup.beagle.android.testutil.RandomData
 import br.com.zup.beagle.android.utils.handleEvent
 import br.com.zup.beagle.android.view.ViewFactory
 import br.com.zup.beagle.android.widget.RootView
-import io.mockk.MockKAnnotations
 import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.every
-import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
@@ -132,7 +130,7 @@ class AlertTest {
     @Test
     fun `should handle onPressOk when click in button`() {
         // Given
-        val onPressOk: Action = mockk(relaxed = true)
+        val onPressOk: List<Action> = listOf()
         val action = Alert(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/action/ConfirmTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/action/ConfirmTest.kt
@@ -83,8 +83,8 @@ class ConfirmTest {
     @Test
     fun `execute should create a ConfirmAction`() {
         // Given
-        val onPressOk: Action = mockk(relaxed = true)
-        val onPressCancel: Action = mockk(relaxed = true)
+        val onPressOk: List<Action> = listOf()
+        val onPressCancel: List<Action> = listOf()
         val action = Confirm(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),
@@ -147,7 +147,7 @@ class ConfirmTest {
     @Test
     fun `should handle onPressOk when click in button`() {
         // Given
-        val onPressOk: Action = mockk(relaxed = true)
+        val onPressOk: List<Action> = listOf()
         val action = Confirm(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),
@@ -174,7 +174,7 @@ class ConfirmTest {
     @Test
     fun `should handle onPressCancel when click in button`() {
         // Given
-        val onPressCancel: Action = mockk(relaxed = true)
+        val onPressCancel: List<Action> = listOf()
         val action = Confirm(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/action/ConfirmTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/action/ConfirmTest.kt
@@ -147,7 +147,7 @@ class ConfirmTest {
     @Test
     fun `should handle onPressOk when click in button`() {
         // Given
-        val onPressOk: List<Action> = listOf()
+        val onPressOk: List<Action> = listOf(mockk(relaxed = true))
         val action = Confirm(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),
@@ -174,7 +174,7 @@ class ConfirmTest {
     @Test
     fun `should handle onPressCancel when click in button`() {
         // Given
-        val onPressCancel: List<Action> = listOf()
+        val onPressCancel: List<Action> = listOf(mockk(relaxed = true))
         val action = Confirm(
             title = constant(RandomData.string()),
             message = constant(RandomData.string()),

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/data/serializer/SerializerDataFactory.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/data/serializer/SerializerDataFactory.kt
@@ -622,12 +622,12 @@ fun makeActionAlertJson() =
         "_beagleAction_": "beagle:alert",
         "title": "A title",
         "message": "A message",
-        "onPressOk": {
+        "onPressOk": [{
              "_beagleAction_": "beagle:alert",
              "title": "Another title",
              "message": "Another message",
              "labelOk": "Ok"
-        },
+        }],
         "labelOk": "Ok"
     }
     """
@@ -636,10 +636,12 @@ fun makeActionAlertObject() = Alert(
     title = constant("A title"),
     message = constant("A message"),
     labelOk = "Ok",
-    onPressOk = Alert(
-        title = constant("Another title"),
-        message = constant("Another message"),
-        labelOk = "Ok"
+    onPressOk = listOf(
+        Alert(
+            title = constant("Another title"),
+            message = constant("Another message"),
+            labelOk = "Ok"
+        )
     )
 )
 
@@ -667,8 +669,8 @@ fun makeActionConfirmJson() = """
         "_beagleAction_": "beagle:confirm",
         "title": "A title",
         "message": "A message",
-        "onPressOk": ${makeActionAlertJson()},
-        "onPressCancel": ${makeActionAlertJson()},
+        "onPressOk": [${makeActionAlertJson()}],
+        "onPressCancel": [${makeActionAlertJson()}],
         "labelOk": "Ok",
         "labelCancel": "Cancel"
     }
@@ -677,9 +679,9 @@ fun makeActionConfirmJson() = """
 fun makeActionConfirmObject() = Confirm(
     title = constant("A title"),
     message = constant("A message"),
-    onPressOk = makeActionAlertObject(),
+    onPressOk = listOf(makeActionAlertObject()),
     labelOk = "Ok",
-    onPressCancel = makeActionAlertObject(),
+    onPressCancel = listOf(makeActionAlertObject()),
     labelCancel = "Cancel",
 )
 
@@ -695,22 +697,6 @@ fun makeActionCustomActionObject() = CustomAndroidAction(
     value = "A value",
     intValue = 123
 )
-
-fun makeActionFormLocalActionJson() = """
-    {
-        "_beagleAction_": "beagle:formlocalaction",
-        "name": "A name",
-        "data": {"test": "test"}
-    }
-"""
-
-fun makeActionFormRemoteActionJson() = """
-    {
-        "_beagleAction_": "beagle:formremoteaction",
-        "path": "$TEST_URL",
-        "method": "POST"
-    }
-"""
 
 fun makeActionOpenExternalURLJson() = """
     {


### PR DESCRIPTION
### Related Issues

https://github.com/ZupIT/beagle/issues/1760

### Description and Example

Add support to the list of actions in fields inside action alert and confirm

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow up on review comments in a timely manner.
- [X] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
