### PR TITLE
fix: adjust send request no execute action onError

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/data/ActionRequester.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/data/ActionRequester.kt
@@ -37,7 +37,7 @@ internal class ActionRequester(
             val call = requestData.doRequest(httpClient, onSuccess = { response ->
                 cont.resume(response)
             }, onError = { response ->
-                cont.resume(response)
+                cont.resumeWithException(BeagleApiException(response, requestData))
             })
             cont.invokeOnCancellation {
                 call.cancel()

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/data/ActionRequesterTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/data/ActionRequesterTest.kt
@@ -91,10 +91,13 @@ class ActionRequesterTest : BaseTest() {
             }
 
             // When
-            val response = actionRequester.fetchAction(requestData)
+            val exception = assertThrows<BeagleApiException> {
+                actionRequester.fetchAction(requestData)
+            }
 
             // Then
-            assertEquals(responseData, response)
+            assertEquals(responseData, exception.responseData)
+            assertEquals(requestData, exception.requestData)
             verify(exactly = 1) { requestData.doRequest(httpClient, any(), onErrorSlot.captured) }
         }
 


### PR DESCRIPTION
### Related Issues

https://github.com/ZupIT/beagle/issues/1759

### Description and Example

Adjust send request no execute action onError

### Checklist

Please, check if these important points are met using `[x]`:

- [X] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [X] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [X] I am willing to follow up on review comments in a timely manner.
- [X] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
