### PR TITLE
feat: adds root id screen analytics

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/BeagleExtensions.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/BeagleExtensions.kt
@@ -44,8 +44,7 @@ internal fun BeagleActivity.configureSupportActionBar() {
     }
 }
 
-fun getRootId(screen: ServerDrivenComponent): String? {
-    if(screen === null) return null
+fun getRootId(screen: ServerDrivenComponent): String {
     if (screen is Container) {
         val containerComponent = screen as Container
         return containerComponent.id.toString()

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/BeagleExtensions.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/BeagleExtensions.kt
@@ -18,8 +18,11 @@
 
 package br.com.zup.beagle.android.utils
 
+import br.com.zup.beagle.android.components.layout.Container
+import br.com.zup.beagle.android.components.layout.ScreenComponent
 import br.com.zup.beagle.android.view.BeagleActivity
 import br.com.zup.beagle.android.view.custom.BeagleNavigator
+import br.com.zup.beagle.core.ServerDrivenComponent
 
 fun String.toAndroidId(): Int {
     // Validation required to avoid conflict of View.generateViewId() with a component's numeral id
@@ -39,4 +42,13 @@ internal fun BeagleActivity.configureSupportActionBar() {
     toolbar.setNavigationOnClickListener {
         BeagleNavigator.popView(this)
     }
+}
+
+fun getRootId(screen: ServerDrivenComponent): String {
+
+    if (screen is Container) {
+        val screenAlt = screen as Container
+        return screenAlt.id.toString()
+    }
+    return (screen as? ScreenComponent)?.identifier.toString()
 }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/BeagleExtensions.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/utils/BeagleExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,11 @@ internal fun BeagleActivity.configureSupportActionBar() {
     }
 }
 
-fun getRootId(screen: ServerDrivenComponent): String {
-
+fun getRootId(screen: ServerDrivenComponent): String? {
+    if(screen === null) return null
     if (screen is Container) {
-        val screenAlt = screen as Container
-        return screenAlt.id.toString()
+        val containerComponent = screen as Container
+        return containerComponent.id.toString()
     }
     return (screen as? ScreenComponent)?.identifier.toString()
 }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/BeagleFragment.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/BeagleFragment.kt
@@ -17,15 +17,12 @@
 package br.com.zup.beagle.android.view
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import br.com.zup.beagle.android.components.layout.Container
-import br.com.zup.beagle.android.components.layout.ScreenComponent
 import br.com.zup.beagle.android.components.utils.applyBackgroundFromWindowBackgroundTheme
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
 import br.com.zup.beagle.android.utils.getRootId

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/BeagleFragment.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/BeagleFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,6 @@ internal class BeagleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         screenViewModel.onScreenLoadFinished()
-        Log.i("teste", "fragment")
 
         screenIdentifier?.let { screenIdentifier ->
             analyticsViewModel.createScreenReport(screenIdentifier, getRootId(screen))

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/BeagleFragment.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/BeagleFragment.kt
@@ -17,14 +17,18 @@
 package br.com.zup.beagle.android.view
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import br.com.zup.beagle.android.components.layout.Container
+import br.com.zup.beagle.android.components.layout.ScreenComponent
 import br.com.zup.beagle.android.components.utils.applyBackgroundFromWindowBackgroundTheme
 import br.com.zup.beagle.android.data.serializer.BeagleSerializer
+import br.com.zup.beagle.android.utils.getRootId
 import br.com.zup.beagle.android.utils.toView
 import br.com.zup.beagle.android.view.viewmodel.AnalyticsViewModel
 import br.com.zup.beagle.android.view.viewmodel.BeagleScreenViewModel
@@ -76,8 +80,10 @@ internal class BeagleFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         screenViewModel.onScreenLoadFinished()
+        Log.i("teste", "fragment")
+
         screenIdentifier?.let { screenIdentifier ->
-            analyticsViewModel.createScreenReport(screenIdentifier)
+            analyticsViewModel.createScreenReport(screenIdentifier, getRootId(screen))
         }
     }
 

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
@@ -17,9 +17,7 @@
 package br.com.zup.beagle.android.view.custom
 
 import android.annotation.SuppressLint
-import android.util.Log
 import android.view.View
-import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.data.formatUrl
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.utils.BeagleRetry

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
@@ -17,11 +17,14 @@
 package br.com.zup.beagle.android.view.custom
 
 import android.annotation.SuppressLint
+import android.util.Log
 import android.view.View
+import br.com.zup.beagle.android.components.layout.Container
 import br.com.zup.beagle.android.data.formatUrl
 import br.com.zup.beagle.android.networking.RequestData
 import br.com.zup.beagle.android.utils.BeagleRetry
 import br.com.zup.beagle.android.utils.generateViewModelInstance
+import br.com.zup.beagle.android.utils.getRootId
 import br.com.zup.beagle.android.view.ScreenRequest
 import br.com.zup.beagle.android.view.ServerDrivenState
 import br.com.zup.beagle.android.view.mapper.toRequestData
@@ -128,9 +131,10 @@ internal class BeagleView(
             addServerDrivenComponent(component)
             loadCompletedListener?.invoke()
         }
+        Log.i("teste", "view")
         screenIdentifier?.let {
             rootView.generateViewModelInstance<AnalyticsViewModel>().createScreenReport(
-                screenIdentifier
+                screenIdentifier, getRootId(component)
             )
         }
     }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/custom/BeagleView.kt
@@ -131,7 +131,6 @@ internal class BeagleView(
             addServerDrivenComponent(component)
             loadCompletedListener?.invoke()
         }
-        Log.i("teste", "view")
         screenIdentifier?.let {
             rootView.generateViewModelInstance<AnalyticsViewModel>().createScreenReport(
                 screenIdentifier, getRootId(component)

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/viewmodel/AnalyticsViewModel.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/viewmodel/AnalyticsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ internal class AnalyticsViewModel : ViewModel() {
         }
     }
 
-    fun createScreenReport(screenIdentifier: String, rootId:String) {
+    fun createScreenReport(screenIdentifier: String, rootId:String? = null) {
         viewModelScope.launch(Dispatchers.Default) {
             AnalyticsService.createScreenRecord(screenIdentifier, rootId)
         }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/view/viewmodel/AnalyticsViewModel.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/view/viewmodel/AnalyticsViewModel.kt
@@ -43,9 +43,9 @@ internal class AnalyticsViewModel : ViewModel() {
         }
     }
 
-    fun createScreenReport(screenIdentifier: String) {
+    fun createScreenReport(screenIdentifier: String, rootId:String) {
         viewModelScope.launch(Dispatchers.Default) {
-            AnalyticsService.createScreenRecord(screenIdentifier)
+            AnalyticsService.createScreenRecord(screenIdentifier, rootId)
         }
     }
 }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsRecord.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsRecord.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsRecord.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsRecord.kt
@@ -39,4 +39,5 @@ data class AnalyticsRecord(
     val additionalEntries: Map<String, Any>? = null,
     val timestamp: Long,
     val screen: String,
+    val rootId:String? = null
 )

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsService.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsService.kt
@@ -46,10 +46,10 @@ internal object AnalyticsService {
         }
     }
 
-    fun createScreenRecord(screenIdentifier: String) {
+    fun createScreenRecord(screenIdentifier: String, rootId:String) {
         val analyticsProvider: AnalyticsProvider? = BeagleEnvironment.beagleSdk.analyticsProvider
         analyticsProvider?.getConfig()?.let {
-            val dataScreenReport = DataScreenReport(screenIdentifier)
+            val dataScreenReport = DataScreenReport(screenIdentifier, rootId)
             reportData(dataScreenReport, analyticsProvider, it)
         }
     }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsService.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/AnalyticsService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ internal object AnalyticsService {
         }
     }
 
-    fun createScreenRecord(screenIdentifier: String, rootId:String) {
+    fun createScreenRecord(screenIdentifier: String, rootId:String? = null) {
         val analyticsProvider: AnalyticsProvider? = BeagleEnvironment.beagleSdk.analyticsProvider
         analyticsProvider?.getConfig()?.let {
             val dataScreenReport = DataScreenReport(screenIdentifier, rootId)

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/DataScreenReport.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/DataScreenReport.kt
@@ -18,10 +18,11 @@ package br.com.zup.beagle.newanalytics
 
 internal data class DataScreenReport(
     val screenIdentifier: String,
+    val rootId: String? = null
 ) : DataReport() {
     override fun report(analyticsConfig: AnalyticsConfig): AnalyticsRecord? {
         if (shouldReportScreen(analyticsConfig)) {
-            return ScreenReportFactory.generateScreenAnalyticsRecord(screenIdentifier, timestamp)
+            return ScreenReportFactory.generateScreenAnalyticsRecord(screenIdentifier, timestamp, rootId?:"NoRootId")
         }
         return null
     }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/DataScreenReport.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/DataScreenReport.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,10 @@ internal data class DataScreenReport(
 ) : DataReport() {
     override fun report(analyticsConfig: AnalyticsConfig): AnalyticsRecord? {
         if (shouldReportScreen(analyticsConfig)) {
-            return ScreenReportFactory.generateScreenAnalyticsRecord(screenIdentifier, timestamp, rootId?:"NoRootId")
+            if (rootId != null && rootId != "null") {
+                return ScreenReportFactory.generateScreenAnalyticsRecord(screenIdentifier, timestamp, rootId)
+            }
+            return ScreenReportFactory.generateScreenAnalyticsRecord(screenIdentifier, timestamp)
         }
         return null
     }

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/ScreenReportFactory.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/ScreenReportFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,15 @@ package br.com.zup.beagle.newanalytics
 internal object ScreenReportFactory {
 
     private const val TYPE_ANALYTICS = "screen"
+
+    fun generateScreenAnalyticsRecord(
+        screenIdentifier: String,
+        timestamp: Long
+    ) = AnalyticsRecord(
+        type = TYPE_ANALYTICS,
+        timestamp = timestamp,
+        screen = screenIdentifier
+    )
 
     fun generateScreenAnalyticsRecord(
         screenIdentifier: String,

--- a/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/ScreenReportFactory.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/newanalytics/ScreenReportFactory.kt
@@ -23,10 +23,12 @@ internal object ScreenReportFactory {
 
     fun generateScreenAnalyticsRecord(
         screenIdentifier: String,
-        timestamp: Long
+        timestamp: Long,
+        rootId: String
     ) = AnalyticsRecord(
         type = TYPE_ANALYTICS,
         timestamp = timestamp,
-        screen = screenIdentifier
+        screen = screenIdentifier,
+        rootId = rootId
     )
 }

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/utils/BeagleExtensionsKtTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/utils/BeagleExtensionsKtTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/utils/BeagleExtensionsKtTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/utils/BeagleExtensionsKtTest.kt
@@ -16,6 +16,10 @@
 
 package br.com.zup.beagle.android.utils
 
+import br.com.zup.beagle.android.components.layout.Container
+import br.com.zup.beagle.android.components.layout.ScreenComponent
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.Test
 
 import org.junit.Assert.assertEquals
@@ -68,6 +72,32 @@ class BeagleExtensionsKtTest {
 
         // Then
         assertEquals(123, result)
+    }
+
+    @Test
+    fun `GIVEN the component IS a Container and has id THEN should return its id otherwhise "null"`() {
+        // Given
+        val container = mockk<Container>(relaxed = true)
+        every { container.id } returns "This id is from the container"
+
+        // Then
+        assertEquals("This id is from the container", getRootId(container))
+
+        every { container.id } returns null
+        assertEquals("null", getRootId(container))
+    }
+
+    @Test
+    fun `GIVEN the component IS a Screen and has identifier THEN should return its identifier otherwise "null"`() {
+        // Given
+        val screen = mockk<ScreenComponent>(relaxed = true)
+        every { screen.identifier } returns "This id is from the screen"
+
+        // Then
+        assertEquals("This id is from the screen", getRootId(screen))
+
+        every { screen.identifier } returns null
+        assertEquals("null", getRootId(screen))
     }
 
 }

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/view/BeagleActivityTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/view/BeagleActivityTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
     private var activity: ServerDrivenActivity? = null
     private val analyticsViewModel = mockk<AnalyticsViewModel>()
     private val screenIdentifierSlot = slot<String>()
+    private val rootIdSlot = slot<String>()
 
     @Before
     fun mockBeforeTest() {
@@ -82,7 +83,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
         val url = "/url"
         val screenRequest = RequestData(url = url)
         prepareViewModelMock(analyticsViewModel)
-        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot)) } just Runs
+        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot),capture(rootIdSlot))} just Runs
 
         //When
         activity?.navigateTo(screenRequest, null)
@@ -90,7 +91,6 @@ class BeagleActivityTest : BaseSoLoaderTest() {
         //Then
         assertEquals(url, screenIdentifierSlot.captured)
     }
-
 
     @Test
     fun `Given a screen with id When navigate to Then should call BeagleFragment newInstance with right parameters`() = runBlockingTest {
@@ -101,7 +101,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
 
 
         prepareViewModelMock(analyticsViewModel)
-        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot)) } just Runs
+        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot), capture(rootIdSlot)) } just Runs
 
         //When
         activity?.navigateTo(screenRequest, screen)
@@ -119,7 +119,7 @@ class BeagleActivityTest : BaseSoLoaderTest() {
 
 
         prepareViewModelMock(analyticsViewModel)
-        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot)) } just Runs
+        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot), capture(rootIdSlot)) } just Runs
 
 
         //When

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/view/BeagleFragmentTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/view/BeagleFragmentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,17 @@ class BeagleFragmentTest : BaseSoLoaderTest() {
 
     private val analyticsViewModel = mockk<AnalyticsViewModel>()
     private val screenIdentifierSlot = slot<String>()
+    private val rootIdSlot = slot<String>()
     private val json = """{
                 "_beagleComponent_" : "beagle:screenComponent",
+                "child" : {
+                "_beagleComponent_" : "beagle:text",
+                "text" : "hello"
+            }
+            }"""
+    private val jsonWithIdentifier = """{
+                "_beagleComponent_" : "beagle:screenComponent",
+                "identifier": "This is an identifier",
                 "child" : {
                 "_beagleComponent_" : "beagle:text",
                 "text" : "hello"
@@ -54,7 +63,7 @@ class BeagleFragmentTest : BaseSoLoaderTest() {
     @Before
     fun mockBeforeTest() {
         prepareViewModelMock(analyticsViewModel)
-        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot)) } just Runs
+        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot), capture(rootIdSlot)) } just Runs
         val activityScenario: ActivityScenario<ServerDrivenActivity> = ActivityScenario.launch(ServerDrivenActivity::class.java)
         activityScenario.onActivity {
             activityScenario.moveToState(Lifecycle.State.RESUMED)
@@ -83,5 +92,17 @@ class BeagleFragmentTest : BaseSoLoaderTest() {
 
         //then
         assertEquals(false, screenIdentifierSlot.isCaptured)
+    }
+
+    @Test
+    fun `Given  a Tree with identifier screen analytics should be called with root Id as identifier`() {
+        //When
+        activity?.supportFragmentManager?.beginTransaction()?.replace(
+            R.id.server_driven_container,
+            BeagleFragment.newInstance(jsonWithIdentifier, url)
+        )?.commit()
+
+        //then
+        assertEquals("This is an identifier", rootIdSlot.captured)
     }
 }

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/view/custom/BeagleViewTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/view/custom/BeagleViewTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ internal class BeagleViewTest : BaseTest() {
     private val analyticsViewModel = mockk<AnalyticsViewModel>()
 
     private val screenIdentifierSlot = slot<String>()
+    private val rootIdSlot = slot<String>()
 
     private val mutableLiveData = MutableLiveData<ViewState>()
     private val url = "/url".formatUrl()
@@ -81,7 +82,7 @@ internal class BeagleViewTest : BaseTest() {
         BeagleSdk.setInTestMode()
         MyBeagleSetup().init(application)
         prepareViewModelMock(analyticsViewModel)
-        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot)) } just Runs
+        every { analyticsViewModel.createScreenReport(capture(screenIdentifierSlot), capture(rootIdSlot)) } just Runs
         every { viewModel.fetchComponent(any(), any()) } returns mutableLiveData
         val activityScenario: ActivityScenario<ServerDrivenActivity> = ActivityScenario.launch(ServerDrivenActivity::class.java)
         activityScenario.onActivity {

--- a/sample/src/main/kotlin/br/com/zup/beagle/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/br/com/zup/beagle/sample/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sample/src/main/kotlin/br/com/zup/beagle/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/br/com/zup/beagle/sample/MainActivity.kt
@@ -63,7 +63,7 @@ class MainActivity : AppCompatActivity() {
     private fun renderScreen() {
         binding.fragmentContent.loadView(
             this,
-            RequestData("https://usebeagle.io/start/welcome")
+            RequestData("/fallback-screen")
         )
     }
 }

--- a/sample/src/main/kotlin/br/com/zup/beagle/sample/SampleAnalytics2.kt
+++ b/sample/src/main/kotlin/br/com/zup/beagle/sample/SampleAnalytics2.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sample/src/main/kotlin/br/com/zup/beagle/sample/SampleAnalytics2.kt
+++ b/sample/src/main/kotlin/br/com/zup/beagle/sample/SampleAnalytics2.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.beaglesampleandroid.beagle
+
+import android.util.Log
+import br.com.zup.beagle.android.annotation.BeagleComponent
+import br.com.zup.beagle.newanalytics.AnalyticsConfig
+import br.com.zup.beagle.newanalytics.AnalyticsProvider
+import br.com.zup.beagle.newanalytics.AnalyticsRecord
+
+@BeagleComponent
+class SampleAnalytics2:AnalyticsProvider {
+    override fun getConfig(): AnalyticsConfig = object: AnalyticsConfig{
+        override var actions: Map<String, List<String>>? = hashMapOf(
+            "beagle:alert" to listOf("message", "title")
+        )
+        override var enableScreenAnalytics: Boolean? = true
+    }
+
+    override fun createRecord(record: AnalyticsRecord) {
+        Log.i("analytics2", record.toString())
+    }
+}

--- a/sample/src/main/kotlin/br/com/zup/beagle/sample/SampleAnalytics2.kt
+++ b/sample/src/main/kotlin/br/com/zup/beagle/sample/SampleAnalytics2.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package br.com.beaglesampleandroid.beagle
+package br.com.zup.beagle.sample
 
 import android.util.Log
 import br.com.zup.beagle.android.annotation.BeagleComponent


### PR DESCRIPTION
### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

### Description and Example

 - Changed the screen record function to have a new property called rootId.
 - When loggin screen events and when presented the rootId will be filled with either the id or identifier of the current 
 component.
- Added test case and updated the old ones with the new interface.


<!--
- if related issues don't already describe the problem you are trying to solve (and why it's important), please say it here
- try to give a small example of the most important thing you actually changed (code snippets, screenshots, file name, and others are welcomed)
-->

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
