### PR TITLE
chore: update link for contributing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Beagle's documentation discusses components, APIs, and topics that are specific 
 
 If you want to contribute to this module, access our [**Contributing Guide**][contribute] to learn about our development process, how to propose bug fixes and improvements, and how to build and test your changes to Beagle.
 
-[contribute]: https://github.com/ZupIT/beagle-ios/blob/main/CONTRIBUTING.md
+[contribute]: https://github.com/ZupIT/beagle-android/blob/main/CONTRIBUTING.md
 
 ### **Developer Certificate of Origin - DCO**
 


### PR DESCRIPTION
Signed-off-by: carlossteinzup <carlos.stein@zup.com.br>

### Description and Example

Contributing link on read was point to the iOS file for contribution. I fixed the link to point to Android file.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [x] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
