### PR TITLE
feat: Fixes AbstractMap crashes with the new MoshiMapJsonAdapter

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/data/serializer/BeagleMoshi.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/data/serializer/BeagleMoshi.kt
@@ -30,6 +30,7 @@ import br.com.zup.beagle.android.data.serializer.adapter.SimpleJsonAdapter
 import br.com.zup.beagle.android.data.serializer.adapter.SimpleJsonArrayAdapter
 import br.com.zup.beagle.android.data.serializer.adapter.defaults.CharSequenceAdapter
 import br.com.zup.beagle.android.data.serializer.adapter.defaults.MoshiArrayListJsonAdapter
+import br.com.zup.beagle.android.data.serializer.adapter.defaults.MoshiMapJsonAdapter
 import br.com.zup.beagle.android.data.serializer.adapter.defaults.PairAdapterFactory
 import br.com.zup.beagle.android.data.serializer.adapter.generic.BeagleGenericAdapterFactory
 import br.com.zup.beagle.android.setup.BeagleEnvironment
@@ -52,6 +53,7 @@ internal object BeagleMoshi {
         .add(AndroidActionJsonAdapterFactory.make())
         .add(ContextDataAdapterFactory())
         .add(MoshiArrayListJsonAdapter.FACTORY)
+        .add(MoshiMapJsonAdapter.FACTORY)
         .add(CharSequenceAdapter())
         .add(PairAdapterFactory)
         .apply {

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/data/serializer/adapter/JsonAdapterUtils.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/data/serializer/adapter/JsonAdapterUtils.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.data.serializer.adapter
+
+import com.squareup.moshi.internal.Util
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+import java.util.Properties
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+internal fun mapKeyAndValueTypes(context: Type, contextRawType: Class<*>?): Array<Type> {
+    // Work around a problem with the declaration of java.util.Properties. That class should extend
+    // Hashtable<String, String>, but it's declared to extend Hashtable<Object, Object>.
+    if (context === Properties::class.java) return arrayOf(String::class.java, String::class.java)
+    val mapType = getSupertype(context, contextRawType!!, MutableMap::class.java)
+    if (mapType is ParameterizedType) {
+        return mapType.actualTypeArguments
+    }
+    return arrayOf(Any::class.java, Any::class.java)
+}
+
+internal fun getSupertype(context: Type?, contextRawType: Class<*>, supertype: Class<*>): Type {
+    require(supertype.isAssignableFrom(contextRawType))
+    return Util.resolve(
+        context, contextRawType, Util.getGenericSupertype(context, contextRawType, supertype))
+}
+
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun <T> knownNotNull(value: T?): T {
+    markNotNull(value)
+    return value
+}
+
+@OptIn(ExperimentalContracts::class)
+@Suppress("NOTHING_TO_INLINE")
+internal inline fun <T> markNotNull(value: T?) {
+    contract {
+        returns() implies (value != null)
+    }
+}

--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/data/serializer/adapter/defaults/MoshiMapJsonAdapter.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/data/serializer/adapter/defaults/MoshiMapJsonAdapter.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020, 2022 ZUP IT SERVICOS EM TECNOLOGIA E INOVACAO SA
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package br.com.zup.beagle.android.data.serializer.adapter.defaults
+
+import br.com.zup.beagle.android.data.serializer.adapter.knownNotNull
+import br.com.zup.beagle.android.data.serializer.adapter.mapKeyAndValueTypes
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonAdapter.Factory
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.rawType
+import java.lang.reflect.Type
+
+/**
+ * This adapter replaces moshi MapJsonAdapter for all Map<K,V> mappings.
+ * With this new implementation we now instantiate a LinkedHashMap instead a LinkedHashTreeMap(internal moshi class).
+ * The error can be reproduced by trying to navigate recursively through the memberProperties of a LinkedHashTreeMap.
+ * At some point we have a AbstractMap$2 that causes the function(memberProperties) below crash for being an
+ * anonymous class.
+ * @see kotlin.reflect.full.memberProperties
+ * @see br.com.zup.beagle.android.analytics.ActionReportFactory
+ * @see com.squareup.moshi.LinkedHashTreeMap
+ */
+internal class MoshiMapJsonAdapter<K, V>(moshi: Moshi, keyType: Type, valueType: Type) : JsonAdapter<Map<K, V?>>() {
+    private val keyAdapter: JsonAdapter<K> = moshi.adapter(keyType)
+    private val valueAdapter: JsonAdapter<V> = moshi.adapter(valueType)
+
+    override fun toJson(writer: JsonWriter, value: Map<K, V?>?) {
+        writer.beginObject()
+        // Never null because we wrap in nullSafe()
+        for ((k, v) in knownNotNull(value)) {
+            if (k == null) {
+                throw JsonDataException("Map key is null at ${writer.path}")
+            }
+            writer.promoteValueToName()
+            keyAdapter.toJson(writer, k)
+            valueAdapter.toJson(writer, v)
+        }
+        writer.endObject()
+    }
+
+    override fun fromJson(reader: JsonReader): Map<K, V?> {
+        val result = LinkedHashMap<K, V?>()
+        reader.beginObject()
+        while (reader.hasNext()) {
+            reader.promoteNameToValue()
+            val name = keyAdapter.fromJson(reader) ?: throw JsonDataException("Map key is null at ${reader.path}")
+            val value = valueAdapter.fromJson(reader)
+            val replaced = result.put(name, value)
+            if (replaced != null) {
+                throw JsonDataException(
+                    "Map key '$name' has multiple values at path ${reader.path}: $replaced and $value"
+                )
+            }
+        }
+        reader.endObject()
+        return result
+    }
+
+    override fun toString() = "JsonAdapter($keyAdapter=$valueAdapter)"
+
+    companion object {
+        val FACTORY = Factory { type, _, moshi ->
+            val rawType = Types.getRawType(type)
+            if (rawType == Map::class.java) {
+                return@Factory newMoshiMapAdapter<Any>(
+                    type,
+                    moshi
+                ).nullSafe()
+            }
+            null
+        }
+
+        private fun <T> newMoshiMapAdapter(type: Type, moshi: Moshi): JsonAdapter<*> {
+            val rawType = type.rawType
+            val keyAndValue = mapKeyAndValueTypes(type, rawType)
+
+            return MoshiMapJsonAdapter<Any, Any>(moshi, keyAndValue[0], keyAndValue[1]).nullSafe()
+        }
+    }
+}

--- a/sample/src/main/kotlin/br/com/zup/beagle/sample/AppDeepLinkHandler.kt
+++ b/sample/src/main/kotlin/br/com/zup/beagle/sample/AppDeepLinkHandler.kt
@@ -17,6 +17,7 @@
 package br.com.zup.beagle.sample
 
 import android.content.Intent
+import android.os.Bundle
 import br.com.zup.beagle.android.annotation.BeagleComponent
 import br.com.zup.beagle.android.navigation.DeepLinkHandler
 import br.com.zup.beagle.android.widget.RootView
@@ -26,5 +27,13 @@ class AppDeepLinkHandler : DeepLinkHandler {
     override fun getDeepLinkIntent(rootView: RootView,
                                    path: String,
                                    data: Map<String, String>?,
-                                   shouldResetApplication: Boolean): Intent = Intent(path)
+                                   shouldResetApplication: Boolean): Intent {
+        val intent = Intent(path)
+        val bundle = Bundle()
+        data?.forEach {
+            bundle.putSerializable(it.key, it.value)
+        }
+        intent.putExtras(bundle)
+        return intent
+    }
 }


### PR DESCRIPTION
Creates a new MapAdapter for moshi that replaces moshi MapJsonAdapter for all Map<K,V> mappings.
With this new implementation we now instantiate a LinkedHashMap instead a LinkedHashTreeMap(internal moshi class),
The error can be reproduced by trying to navigate recursively through the memberProperties of a LinkedHashTreeMa
 At some point we have a AbstractMap$2 that causes the function(memberProperties) below crash for being an
 Anonymous class

### Related Issues

<!--
- list all issues that are related to this PR (e.g: "#123, #124)
- if this PR closes some issue, use "Closes #123"
-->

fixes https://github.com/ZupIT/beagle/issues/1805

### Description and Example

> ## Description 
> An error _**kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Unresolved class: class java.util.AbstractMap$2**_ happens when DATA properties are set on the Navigate OpenNativeRoute.
> 
> The application crashes when the `ActionReportFactory` tries to get the parameters from this action
> 
> ## Steps To Reproduce
> 1. Implement some DATA on the openNativeRoute Navigate Action in a backend
> 
> ```
> Navigate.OpenNativeRoute(
>                             route = "screen-native", //TODO You must implement an Deep Link Handler and list it's path here
>                             data = hashMapOf("x" to "Parameter1", "y" to "Parameter2")
>                         )
> ```
> 
> 2. Implement the DeepLink Handler on the front end
> 
> ```
> @BeagleComponent
> class AppDeepLinkHandler : DeepLinkHandler {
>     override fun getDeepLinkIntent(rootView: RootView,
>                                    path: String,
>                                    data: Map<String, String>?,
>                                    shouldResetApplication: Boolean): Intent {
>         val intent = Intent(path)
>         val bundle = Bundle()
>         data?.forEach {
>             bundle.putSerializable(it.key, it.value)
>         }
>         intent.putExtras(bundle)
>         return intent
>     }}
> ```
> 
> 3. Register an activity to be open via DeepLink, add the intent filter to the Android Manifest
> 
> ```
> <intent-filter>
>                 <action android:name="screen-native" />
>                 <category android:name="android.intent.category.DEFAULT" />
>             </intent-filter>
> ```
> 
> 4. The application will crash with the error _**kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Unresolved class: class java.util.AbstractMap$2**_
> 
> * The activity called via deeplink may still open, but it will open in a new application, since the previous one have crashed.
> 
> ## Expected Results
> The activity should open and the application should not crash. There musn't be any error in analytics provider. The Analytics should be able to get the properties properly.
> 
> ## Code example, screenshot, or link to a repository:
> Codes were provided above.
> 
> ## Error log:
> ´´´ E/AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-2 Process: br.com.zup.beagle.sample, PID: 13116 kotlin.reflect.jvm.internal.KotlinReflectionInternalError: Unresolved class: class java.util.AbstractMap$2 at kotlin.reflect.jvm.internal.KClassImpl.reportUnresolvedClass(KClassImpl.kt:329) at kotlin.reflect.jvm.internal.KClassImpl.access$reportUnresolvedClass(KClassImpl.kt:44) at kotlin.reflect.jvm.internal.KClassImpl$Data$descriptor$2.invoke(KClassImpl.kt:56) at kotlin.reflect.jvm.internal.KClassImpl$Data$descriptor$2.invoke(KClassImpl.kt:47) at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:92) at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:31) at kotlin.reflect.jvm.internal.KClassImpl$Data.getDescriptor(Unknown Source:7) at kotlin.reflect.jvm.internal.KClassImpl.getDescriptor(KClassImpl.kt:182) at kotlin.reflect.jvm.internal.KClassImpl.getMemberScope$kotlin_reflection(KClassImpl.kt:191) at kotlin.reflect.jvm.internal.KClassImpl$Data$declaredNonStaticMembers$2.invoke(KClassImpl.kt:162) at kotlin.reflect.jvm.internal.KClassImpl$Data$declaredNonStaticMembers$2.invoke(KClassImpl.kt:47) at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:92) at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:31) at kotlin.reflect.jvm.internal.KClassImpl$Data.getDeclaredNonStaticMembers(Unknown Source:8) at kotlin.reflect.jvm.internal.KClassImpl$Data$allNonStaticMembers$2.invoke(KClassImpl.kt:171) at kotlin.reflect.jvm.internal.KClassImpl$Data$allNonStaticMembers$2.invoke(KClassImpl.kt:47) at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:92) at kotlin.reflect.jvm.internal.ReflectProperties$Val.getValue(ReflectProperties.java:31) at kotlin.reflect.jvm.internal.KClassImpl$Data.getAllNonStaticMembers(Unknown Source:8) at kotlin.reflect.full.KClasses.getMemberProperties(KClasses.kt:149) at br.com.zup.beagle.android.analytics.ActionReportFactory.evaluateAllActionAttribute(ActionReportFactory.kt:103) at br.com.zup.beagle.android.analytics.ActionReportFactory.evaluateAllActionAttribute(ActionReportFactory.kt:109) at br.com.zup.beagle.android.analytics.ActionReportFactory.evaluateAllActionAttribute(ActionReportFactory.kt:109) at br.com.zup.beagle.android.analytics.ActionReportFactory.evaluateAllActionAttribute$default(ActionReportFactory.kt:92) at br.com.zup.beagle.android.analytics.ActionReportFactory.generateDataActionReport(ActionReportFactory.kt:51) at br.com.zup.beagle.android.analytics.AnalyticsService.createActionRecord(AnalyticsService.kt:39) at br.com.zup.beagle.android.view.viewmodel.AnalyticsViewModel$createActionReport$1.invokeSuspend(AnalyticsViewModel.kt:37) at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106) at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571) at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750) at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678) at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665) I/Process: Sending signal. PID: 13116 SIG: 9 ´´´



### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
