### PR TITLE
fix: SetContext allow contextId in path

### DIFF
--- a/beagle/src/main/kotlin/br/com/zup/beagle/android/context/ContextDataManipulator.kt
+++ b/beagle/src/main/kotlin/br/com/zup/beagle/android/context/ContextDataManipulator.kt
@@ -43,7 +43,7 @@ internal class ContextDataManipulator(
             ContextSetResult.Succeed(context.copy(value = value))
         } else {
             try {
-                val keys = createKeysFromPath(context.id, path)
+                val keys = JsonPathUtils.splitKeys(path)
                 val newContext = updateContextDataWithTree(context, keys)
                 jsonCreateTree.walkingTreeAndFindKey(newContext.value, keys, value)
                 ContextSetResult.Succeed(newContext)

--- a/beagle/src/test/kotlin/br/com/zup/beagle/android/context/ContextDataManipulatorTest.kt
+++ b/beagle/src/test/kotlin/br/com/zup/beagle/android/context/ContextDataManipulatorTest.kt
@@ -75,7 +75,7 @@ class ContextDataManipulatorTest : BaseTest() {
     }
 
     @Test
-    fun `set should ignore contextId and replace context value when path is empty`() {
+    fun `set should allow contextId key in path and correctly update context value`() {
         // Given
         val context = ContextData(
             id = CONTEXT_ID,
@@ -89,7 +89,7 @@ class ContextDataManipulatorTest : BaseTest() {
 
         // Then
         val newValue = (result as ContextSetResult.Succeed).newContext.value.toString()
-        assertEquals("{\"a\":false}", newValue)
+        assertEquals("{\"$CONTEXT_ID\":{\"a\":false}}", newValue)
     }
 
     @Test


### PR DESCRIPTION
Signed-off-by: Daniel Tes Carrasque <daniel@zup.com.br>

### Related Issues
Fixes [#1810](https://github.com/ZupIT/beagle/issues/1810)

### Description and Example

Removes a constraint on the set that did not allow starting the path with a key equal to the contextid.

### Checklist

Please, check if these important points are met using `[x]`:

- [x] I read the [PR Guide] and followed the process outlined there for submitting this PR.
- [x] I avoided _breaking changes_ by not changing public APIs that people rely on. <!-- if that wasn't possible, please tell us why and how it changed -->
- [x] I am willing to follow-up on review comments in a timely manner.
- [ ] I have made the documentation changes or I created an issue explaining how to document this change on [Docs issues](https://github.com/ZupIT/beagle-docs/issues). Please link the issue here:

<!-- Links -->
[PR Guide]: https://github.com/ZupIT/beagle-android/blob/main/doc/contributing/pull_requests.md
